### PR TITLE
Inserting space in the message

### DIFF
--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -3574,7 +3574,7 @@ msgid "          owned by: "
 msgstr "        pertence a: "
 
 msgid "   dated: "
-msgstr "com data: "
+msgstr "   com data: "
 
 msgid "             dated: "
 msgstr "       com data de: "


### PR DESCRIPTION
Alert message is showing username concatenating with date message. To make the correction, I put 3 space in front of the message.

![image](https://user-images.githubusercontent.com/13952867/171884178-0aa13fa2-f740-4c69-9826-f7e19cfa2188.png)
